### PR TITLE
add None-check after node inference in DagChecker

### DIFF
--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -70,8 +70,10 @@ class DagChecker(checkers.BaseChecker):
             hasattr(func, "attrname") and func.attrname == "DAG"
         ):
             function_node = safe_infer(func)
-            if function_node.is_subtype_of("airflow.models.DAG") or function_node.is_subtype_of(
-                "airflow.models.dag.DAG"  # TODO: are both of these subtypes relevant?
+            if function_node and (
+                function_node.is_subtype_of("airflow.models.DAG")
+                or function_node.is_subtype_of("airflow.models.dag.DAG")
+                # ^ TODO: are both of these subtypes relevant?
             ):
                 # Check for "dag_id" as keyword arg
                 if call_node.keywords is not None:  # TODO: can just use 'is not'?

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -325,14 +325,11 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
 
         assert result == ("my_dag", test_call)
 
-    @pytest.mark.xfail(reason="Not yet implemented", raises=AttributeError, strict=True)
     def test_future_work_unimported_dag_module_should_return_none(self):
-        """Currently, the DAG checker does not null-check before matching the node class type,
-        so if the node inference fails, the type check raises an AttributeError and blows up the
-        checker call. This should be changed to fail gracefully by returning (None, None).
-
-        This test notes the unimplemented behavior; when fixed, the test case should be moved
-        into the failure path test above."""
+        """If the code calls a DAG constructor but hasn't imported the appropriate module,
+        node inference will fail and return None; we must None-check the inferred node before
+        performing the type check, to avoid an AttributeError. and blows up the checker call.
+        """
         test_code = """DAG("my_dag")  #@"""
 
         test_call = astroid.extract_node(test_code)

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -328,7 +328,7 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
     def test_future_work_unimported_dag_module_should_return_none(self):
         """If the code calls a DAG constructor but hasn't imported the appropriate module,
         node inference will fail and return None; we must None-check the inferred node before
-        performing the type check, to avoid an AttributeError. and blows up the checker call.
+        performing the type check, to avoid an AttributeError that blows up the checker call.
         """
         test_code = """DAG("my_dag")  #@"""
 


### PR DESCRIPTION
If the user code calls a DAG constructor but hasn't imported the appropriate module, the node inference in DagChecker._find_dag_in_call_node will fail and return None. We must None-check the inferred node before performing the type check, to avoid an AttributeError that blows up the checker call.
