### PR TITLE
refactor and clean DagChecker._find_dag_in_call_node()

### DIFF
--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -13,6 +13,8 @@ from pylint_airflow.__pkginfo__ import BASE_ID
 
 @dataclass
 class DagCallNode:
+    """Data class to hold dag_id and a call node returning a DAG with that dag_id"""
+
     dag_id: str
     call_node: astroid.Call
 
@@ -65,11 +67,10 @@ class DagChecker(checkers.BaseChecker):
         call_node: astroid.Call, func: Union[astroid.Name, astroid.Attribute]
     ) -> Union[DagCallNode, None]:
         """
-        Find DAG in a call_node. Returns (None, None) if no DAG is found.
+        Find DAG in a call_node. Returns None if no DAG is found.
         :param call_node:
         :param func:
-        :return: (dag_id: str, node: astroid.Call)
-        :rtype: Tuple  TODO: replace tuple with dataclass
+        :return: DagCallNode of dag_id and call_node
         """
         # check for both 'DAG(dag_id="mydag")' and e.g. 'models.DAG(dag_id="mydag")'
         if (hasattr(func, "name") and func.name == "DAG") or (  # TODO: use type checks

--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -1,6 +1,6 @@
 """Checks on Airflow DAGs."""
-
 from collections import defaultdict, OrderedDict
+from dataclasses import dataclass
 from typing import Tuple, Union, Dict, List
 
 import astroid
@@ -9,6 +9,12 @@ from pylint.checkers import utils
 from pylint.checkers.utils import safe_infer
 
 from pylint_airflow.__pkginfo__ import BASE_ID
+
+
+@dataclass
+class DagCallNode:
+    dag_id: str
+    call_node: astroid.Call
 
 
 class DagChecker(checkers.BaseChecker):

--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -74,8 +74,8 @@ class DagChecker(checkers.BaseChecker):
         func = call_node.func
 
         # check for both 'DAG(dag_id="mydag")' and e.g. 'models.DAG(dag_id="mydag")'
-        if (hasattr(func, "name") and func.name == "DAG") or (  # TODO: use type checks
-            hasattr(func, "attrname") and func.attrname == "DAG"
+        if (isinstance(func, astroid.Name) and func.name == "DAG") or (
+            isinstance(func, astroid.Attribute) and func.attrname == "DAG"
         ):
             function_node = safe_infer(func)
             if function_node and (

--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -64,6 +64,7 @@ class DagChecker(checkers.BaseChecker):
 
     @staticmethod
     def _find_dag_in_call_node(call_node: astroid.Call) -> Union[DagCallNode, None]:
+        # pylint: disable=too-many-nested-blocks
         """
         Find DAG in a call_node. Returns None if no DAG is found.
         :param call_node:

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -239,7 +239,7 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
 
         test_call = astroid.extract_node(test_code)
 
-        result = DagChecker._find_dag_in_call_node(test_call, test_call.func)
+        result = DagChecker._find_dag_in_call_node(test_call)
 
         assert result == DagCallNode("my_dag", test_call)
 
@@ -273,7 +273,7 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
         """
         test_call = astroid.extract_node(test_code)
 
-        result = DagChecker._find_dag_in_call_node(test_call, test_call.func)
+        result = DagChecker._find_dag_in_call_node(test_call)
 
         assert result is None
 
@@ -321,7 +321,7 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
 
         test_call = astroid.extract_node(test_code)
 
-        result = DagChecker._find_dag_in_call_node(test_call, test_call.func)
+        result = DagChecker._find_dag_in_call_node(test_call)
 
         assert result == ("my_dag", test_call)
 
@@ -334,7 +334,7 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
 
         test_call = astroid.extract_node(test_code)
 
-        result = DagChecker._find_dag_in_call_node(test_call, test_call.func)
+        result = DagChecker._find_dag_in_call_node(test_call)
 
         assert result is None
 

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -8,7 +8,7 @@ import pytest
 from pylint.testutils import CheckerTestCase, MessageTest
 
 import pylint_airflow
-from pylint_airflow.checkers.dag import DagChecker
+from pylint_airflow.checkers.dag import DagChecker, DagCallNode
 
 
 @pytest.fixture(name="test_dagids_to_nodes")
@@ -241,7 +241,7 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
 
         result = DagChecker._find_dag_in_call_node(test_call, test_call.func)
 
-        assert result == ("my_dag", test_call)
+        assert result == DagCallNode("my_dag", test_call)
 
     @pytest.mark.parametrize(
         "test_statement",
@@ -275,7 +275,7 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
 
         result = DagChecker._find_dag_in_call_node(test_call, test_call.func)
 
-        assert result == (None, None)
+        assert result is None
 
     @pytest.mark.parametrize(
         "test_statement",
@@ -336,7 +336,7 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
 
         result = DagChecker._find_dag_in_call_node(test_call, test_call.func)
 
-        assert result == (None, None)
+        assert result is None
 
 
 class TestDagIdsToDeduplicatedNodesHelper:  # pylint: disable=protected-access,missing-function-docstring

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -8,7 +8,7 @@ import pytest
 from pylint.testutils import CheckerTestCase, MessageTest
 
 import pylint_airflow
-from pylint_airflow.checkers.dag import DagChecker, DagCallNode
+from pylint_airflow.checkers.dag import DagCallNode, DagChecker
 
 
 @pytest.fixture(name="test_dagids_to_nodes")


### PR DESCRIPTION
Improvements to the _find_dag_in_call_node() method:
- Remove `func` argument (get it from `call_node` argument)
- Change return type from tuple to custom DagCallNode data class containing `dag_id` and `call_node`
- Check for Name and Attribute by types instead of examining attributes
- Clean up some code blocks