### PR TITLE
detect dag_ids from variables

### DIFF
--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -103,6 +103,11 @@ class DagChecker(checkers.BaseChecker):
                     # Only constants supported, TODO: support dynamic dag_id
                     if isinstance(first_positional_arg, astroid.Const):
                         return DagCallNode(str(first_positional_arg.value), call_node)
+                    if isinstance(first_positional_arg, astroid.Name):
+                        name_val = safe_infer(first_positional_arg)
+                        if isinstance(name_val, astroid.Const):
+                            return DagCallNode(str(name_val.value), call_node)
+
                     return None
 
         return None

--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -92,6 +92,10 @@ class DagChecker(checkers.BaseChecker):
                             kw_val = keyword.value
                             if isinstance(kw_val, astroid.Const):
                                 return DagCallNode(str(kw_val.value), call_node)
+                            if isinstance(kw_val, astroid.Name):
+                                name_val = safe_infer(kw_val)
+                                if isinstance(name_val, astroid.Const):
+                                    return DagCallNode(str(name_val.value), call_node)
 
                 # Check for dag_id as positional arg
                 if call_node.args:

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -296,10 +296,10 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
             'test_id = "my_dag"\n        models.DAG(dag_id=f"{test_id}_0")',
             'test_id = "my_dag"\n        DAG(f"{test_id}_0")',
             'test_id = "my_dag"\n        models.DAG(f"{test_id}_0")',
-            'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        DAG(my_id=f"{test_id}_0")',
-            'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        models.DAG(my_id=f"{test_id}_0")',  # pylint: disable=line-too-long
-            'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        DAG(f"{test_id}_0")',
-            'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        models.DAG(f"{test_id}_0")',  # pylint: disable=line-too-long
+            'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        DAG(dag_id=my_id)',
+            'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        models.DAG(dag_id=my_id)',
+            'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        DAG(my_id)',
+            'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        models.DAG(my_id)',
         ],
         ids=[
             "DAG Name call with f-string dag_id keyword argument",

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -290,7 +290,6 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
             'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        models.DAG(my_id=f"{test_id}_0")',  # pylint: disable=line-too-long
             'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        DAG(f"{test_id}_0")',
             'test_id = "my_dag"\n        my_id = f"{test_id}_0"\n        models.DAG(f"{test_id}_0")',  # pylint: disable=line-too-long
-            "bupkus()",
         ],
         ids=[
             "DAG Name call with variable dag_id keyword argument",
@@ -305,7 +304,6 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
             "DAG Attribute call with double-variable dag_id keyword argument",
             "DAG Name call with double-variable dag_id positional argument",
             "DAG Attribute call with double-variable dag_id positional argument",
-            "Nonsense unbound function name",
         ],
     )
     @pytest.mark.xfail(reason="Not yet implemented", raises=AssertionError, strict=True)


### PR DESCRIPTION
If a constant is assigned to a variable and the variable used as a dag_id argument, pylint-airflow will detect the variable's value as the dag_id.