### PR TITLE
refactor operator checker

### DIFF
--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -191,6 +191,7 @@ class DagChecker(checkers.BaseChecker):
     @utils.only_required_for_messages("duplicate-dag-name", "match-dagid-filename")
     def visit_module(self, node: astroid.Module):
         """We must peruse an entire module to detect inter-DAG issues."""
+        # TODO: add check to force kwargs for DAG definitions
         dagids_to_nodes: Dict[str, List[astroid.Call]] = defaultdict(list)
 
         self.collect_dags_in_assignments(node, dagids_to_nodes)

--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -10,6 +10,46 @@ from pylint.checkers.utils import safe_infer
 
 from pylint_airflow.__pkginfo__ import BASE_ID
 
+DAG_CHECKER_MSGS = {
+    f"W{BASE_ID}00": (
+        "TODO Don't place BaseHook calls at the top level of DAG script",
+        "basehook-top-level",
+        "TODO Airflow executes DAG scripts periodically and anything at the top level "
+        "of a script is executed. Therefore, move BaseHook calls into "
+        "functions/hooks/operators.",
+    ),
+    f"E{BASE_ID}00": (
+        "DAG name %s already used",
+        "duplicate-dag-name",
+        "DAG name should be unique.",
+    ),
+    f"E{BASE_ID}01": (
+        "TODO Task name {} already used",
+        "duplicate-task-name",
+        "TODO Task name within a DAG should be unique.",
+    ),
+    f"E{BASE_ID}02": (
+        "TODO Task dependency {}->{} already set",
+        "duplicate-dependency",
+        "TODO Task dependencies can be defined only once.",
+    ),
+    f"E{BASE_ID}03": (
+        "TODO DAG {} contains cycles",
+        "dag-with-cycles",
+        "TODO A DAG is acyclic and cannot contain cycles.",
+    ),
+    f"E{BASE_ID}04": (
+        "TODO Task {} is not bound to any DAG instance",
+        "task-no-dag",
+        "TODO A task must know a DAG instance to run.",
+    ),
+    f"C{BASE_ID}06": (
+        "For consistency match the DAG filename with the dag_id",
+        "match-dagid-filename",
+        "For consistency match the DAG filename with the dag_id.",
+    ),
+}
+
 
 @dataclass
 class DagCallNode:
@@ -134,45 +174,7 @@ def find_dag_in_call_node(call_node: astroid.Call) -> Optional[DagCallNode]:
 class DagChecker(checkers.BaseChecker):
     """Checks conditions in the context of (a) complete DAG(s)."""
 
-    msgs = {
-        f"W{BASE_ID}00": (
-            "Don't place BaseHook calls at the top level of DAG script",
-            "basehook-top-level",
-            "Airflow executes DAG scripts periodically and anything at the top level "
-            "of a script is executed. Therefore, move BaseHook calls into "
-            "functions/hooks/operators.",
-        ),
-        f"E{BASE_ID}00": (
-            "DAG name %s already used",
-            "duplicate-dag-name",
-            "DAG name should be unique.",
-        ),
-        f"E{BASE_ID}01": (
-            "Task name {} already used",
-            "duplicate-task-name",
-            "Task name within a DAG should be unique.",
-        ),
-        f"E{BASE_ID}02": (
-            "Task dependency {}->{} already set",
-            "duplicate-dependency",
-            "Task dependencies can be defined only once.",
-        ),
-        f"E{BASE_ID}03": (
-            "DAG {} contains cycles",
-            "dag-with-cycles",
-            "A DAG is acyclic and cannot contain cycles.",
-        ),
-        f"E{BASE_ID}04": (
-            "Task {} is not bound to any DAG instance",
-            "task-no-dag",
-            "A task must know a DAG instance to run.",
-        ),
-        f"C{BASE_ID}06": (
-            "For consistency match the DAG filename with the dag_id",
-            "match-dagid-filename",
-            "For consistency match the DAG filename with the dag_id.",
-        ),
-    }
+    msgs = DAG_CHECKER_MSGS
 
     @staticmethod
     def _dagids_to_deduplicated_nodes(

--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -48,6 +48,7 @@ DAG_CHECKER_MSGS = {
         "match-dagid-filename",
         "For consistency match the DAG filename with the dag_id.",
     ),
+    # TODO: add check to force kwargs for DAG definitions
 }
 
 
@@ -83,7 +84,7 @@ def value_from_const_node(const_node: astroid.Const) -> Optional[str]:
 def value_from_name_node(name_node: astroid.Name) -> Optional[str]:
     """Returns a DagCallNode instance with dag_id extracted from the name_node argument,
     or None if the node value can't be extracted."""
-    name_val = safe_infer(name_node)  # TODO: follow name chains
+    name_val = safe_infer(name_node)
     if name_val:
         if isinstance(name_val, astroid.Const):
             return value_from_const_node(name_val)
@@ -191,7 +192,6 @@ class DagChecker(checkers.BaseChecker):
     @utils.only_required_for_messages("duplicate-dag-name", "match-dagid-filename")
     def visit_module(self, node: astroid.Module):
         """We must peruse an entire module to detect inter-DAG issues."""
-        # TODO: add check to force kwargs for DAG definitions
         dagids_to_nodes: Dict[str, List[astroid.Call]] = defaultdict(list)
 
         self.collect_dags_in_assignments(node, dagids_to_nodes)

--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -105,12 +105,12 @@ def get_name_node_value_from_assignments(node: astroid.Name) -> Optional[str]:
                 assign_value = assign_node.value
                 return dag_id_from_argument_value(assign_value)
 
-        # If we drop out of any of 'if' blocks, we give up
+        # If we drop out of any 'if' blocks, we give up
         return None
 
 
 def value_from_joined_str_node(joined_str_node: astroid.JoinedStr) -> Optional[str]:
-    """Returns a DagCallNode instance with dag_id composed from the elements of the
+    """Returns a DagCallNode instance with dag_id composed by joining the elements of the
     joined_str_node argument, or None if the node value can't be extracted."""
     dag_id_elements: List[str] = []
     for js_value in joined_str_node.values:

--- a/src/pylint_airflow/checkers/operator.py
+++ b/src/pylint_airflow/checkers/operator.py
@@ -161,7 +161,7 @@ class OperatorChecker(checkers.BaseChecker):
             try:
                 task_parameters = get_task_parameters_from_assign(node)
             except ValueError as val_err:
-                logging.warning("Task assignment expression could not be analyzed\n%s", ve)
+                logging.warning("Task assignment expression could not be analyzed\n%s", val_err)
             else:
                 self.check_operator_varname_versus_task_id(node, task_parameters)
                 self.check_callable_name_versus_task_id(node, task_parameters)

--- a/src/pylint_airflow/checkers/operator.py
+++ b/src/pylint_airflow/checkers/operator.py
@@ -160,7 +160,7 @@ class OperatorChecker(checkers.BaseChecker):
         if is_assign_call_subtype_of_base_operator(node):
             try:
                 task_parameters = get_task_parameters_from_assign(node)
-            except ValueError as ve:
+            except ValueError as val_err:
                 logging.warning("Task assignment expression could not be analyzed\n%s", ve)
             else:
                 self.check_operator_varname_versus_task_id(node, task_parameters)

--- a/src/pylint_airflow/checkers/operator.py
+++ b/src/pylint_airflow/checkers/operator.py
@@ -104,11 +104,25 @@ class OperatorChecker(checkers.BaseChecker):
                     if keyword.arg == "python_callable":
                         python_callable_name = keyword.value.name
 
-                if var_name != task_id:
-                    self.add_message("different-operator-varname-taskid", node=node)
+                self.check_operator_varname_versus_task_id(node, var_name, task_id)
 
-                if python_callable_name and f"_{task_id}" != python_callable_name:
-                    self.add_message("match-callable-taskid", node=node)
+                self.check_callable_name_versus_task_id(node, python_callable_name, task_id)
+
+    def check_operator_varname_versus_task_id(
+        self, node: astroid.Assign, var_name: str, task_id: str
+    ) -> None:
+        """Adds a message if the assigned variable name and the task ID do not match.
+        A message is not added if either string argument is empty ("") or None."""
+        if var_name and task_id and var_name != task_id:
+            self.add_message("different-operator-varname-taskid", node=node)
+
+    def check_callable_name_versus_task_id(
+        self, node: astroid.Assign, python_callable_name: str, task_id: str
+    ):
+        """Adds a message if the callable name and the task ID prefixed with an underscore
+        do not match. A message is not added if either string argument is empty ("") or None."""
+        if python_callable_name and task_id and f"_{task_id}" != python_callable_name:
+            self.add_message("match-callable-taskid", node=node)
 
     @utils.only_required_for_messages("mixed-dependency-directions")
     def visit_binop(self, node):

--- a/src/pylint_airflow/checkers/operator.py
+++ b/src/pylint_airflow/checkers/operator.py
@@ -7,6 +7,44 @@ from pylint.checkers.utils import safe_infer
 
 from pylint_airflow.__pkginfo__ import BASE_ID
 
+OPERATOR_CHECKER_MSGS = {
+    f"C{BASE_ID}00": (
+        "Operator variable name and task_id argument should match",
+        "different-operator-varname-taskid",
+        "For consistency assign the same variable name and task_id to operators.",
+    ),
+    f"C{BASE_ID}01": (
+        "Name the python_callable function '_[task_id]'",
+        "match-callable-taskid",
+        "For consistency name the callable function '_[task_id]', e.g. "
+        "PythonOperator(task_id='mytask', python_callable=_mytask).",
+    ),
+    f"C{BASE_ID}02": (
+        "Avoid mixing task dependency directions",
+        "mixed-dependency-directions",
+        "For consistency don't mix directions in a single statement, instead split "
+        "over multiple statements.",
+    ),
+    f"C{BASE_ID}03": (
+        "TODO Task {} has no dependencies. Verify or disable message.",
+        "task-no-dependencies",
+        "TODO Sometimes a task without any dependency is desired, however often it is "
+        "the result of a forgotten dependency.",
+    ),
+    f"C{BASE_ID}04": (
+        "TODO Rename **kwargs variable to **context to show intent for Airflow task context",
+        "task-context-argname",
+        "TODO Indicate you expect Airflow task context variables in the **kwargs "
+        "argument by renaming to **context.",
+    ),
+    f"C{BASE_ID}05": (
+        "TODO Extract variables from keyword arguments for explicitness",
+        "task-context-separate-arg",
+        "TODO To avoid unpacking kwargs from the Airflow task context in a function, you "
+        "can set the needed variables as arguments in the function.",
+    ),
+}
+
 
 def collect_binops(working_node: astroid.BinOp):
     """
@@ -26,43 +64,7 @@ def collect_binops(working_node: astroid.BinOp):
 class OperatorChecker(checkers.BaseChecker):
     """Checks on Airflow operators."""
 
-    msgs = {
-        f"C{BASE_ID}00": (
-            "Operator variable name and task_id argument should match",
-            "different-operator-varname-taskid",
-            "For consistency assign the same variable name and task_id to operators.",
-        ),
-        f"C{BASE_ID}01": (
-            "Name the python_callable function '_[task_id]'",
-            "match-callable-taskid",
-            "For consistency name the callable function '_[task_id]', e.g. "
-            "PythonOperator(task_id='mytask', python_callable=_mytask).",
-        ),
-        f"C{BASE_ID}02": (
-            "Avoid mixing task dependency directions",
-            "mixed-dependency-directions",
-            "For consistency don't mix directions in a single statement, instead split "
-            "over multiple statements.",
-        ),
-        f"C{BASE_ID}03": (
-            "Task {} has no dependencies. Verify or disable message.",
-            "task-no-dependencies",
-            "Sometimes a task without any dependency is desired, however often it is "
-            "the result of a forgotten dependency.",
-        ),
-        f"C{BASE_ID}04": (
-            "Rename **kwargs variable to **context to show intent for Airflow task context",
-            "task-context-argname",
-            "Indicate you expect Airflow task context variables in the **kwargs "
-            "argument by renaming to **context.",
-        ),
-        f"C{BASE_ID}05": (
-            "Extract variables from keyword arguments for explicitness",
-            "task-context-separate-arg",
-            "To avoid unpacking kwargs from the Airflow task context in a function, you "
-            "can set the needed variables as arguments in the function.",
-        ),
-    }
+    msgs = OPERATOR_CHECKER_MSGS
 
     @utils.only_required_for_messages("different-operator-varname-taskid", "match-callable-taskid")
     def visit_assign(self, node):

--- a/src/pylint_airflow/checkers/operator.py
+++ b/src/pylint_airflow/checkers/operator.py
@@ -98,6 +98,8 @@ class OperatorChecker(checkers.BaseChecker):
         def invalidname(): print("dosomething")
         mytask = PythonOperator(task_id="mytask", python_callable=invalidname)
         """
+        # TODO: add check to force kwargs for task definitions
+
         if is_assign_call_subtype_of_base_operator(node):
             var_name = node.targets[0].name
             task_id = None

--- a/src/pylint_airflow/checkers/operator.py
+++ b/src/pylint_airflow/checkers/operator.py
@@ -116,7 +116,10 @@ def get_task_parameters_from_assign(node: astroid.Assign) -> TaskParameters:
 
     assign_target = node.targets[0]
     if not isinstance(assign_target, astroid.AssignName):
-        raise ValueError(f"Target of Assign node {node} is not a Name; task cannot be linted.")
+        raise ValueError(
+            f"Target of Assign node {node} is not an AssignName ({assign_target});"
+            f" task cannot be linted."
+        )
 
     var_name = assign_target.name
     task_id = None

--- a/tests/pylint_airflow/checkers/test_operator.py
+++ b/tests/pylint_airflow/checkers/test_operator.py
@@ -97,6 +97,12 @@ class TestOperatorChecker(CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_assign(assign_node)
 
+
+class TestCheckMixedDependencyDirections(CheckerTestCase):
+    """Tests for the Operator checker."""
+
+    CHECKER_CLASS = pylint_airflow.checkers.operator.OperatorChecker
+
     @pytest.mark.parametrize(
         "dependencies,expect_msg",
         [

--- a/tests/pylint_airflow/checkers/test_operator.py
+++ b/tests/pylint_airflow/checkers/test_operator.py
@@ -138,7 +138,7 @@ class TestCheckMixedDependencyDirections(CheckerTestCase):
             with self.assertAddsMessages(
                 MessageTest(msg_id=message, node=binop_node), ignore_position=True
             ):
-                self.checker.visit_binop(binop_node)
+                self.checker.check_mixed_dependency_directions(binop_node)
         else:
             with self.assertNoMessages():
-                self.checker.visit_binop(binop_node)
+                self.checker.check_mixed_dependency_directions(binop_node)

--- a/tests/pylint_airflow/checkers/test_operator.py
+++ b/tests/pylint_airflow/checkers/test_operator.py
@@ -5,6 +5,7 @@ import pytest
 from pylint.testutils import CheckerTestCase, MessageTest
 
 import pylint_airflow
+from pylint_airflow.checkers.operator import TaskParameters
 
 
 class TestOperatorChecker(CheckerTestCase):
@@ -113,7 +114,7 @@ class TestCheckOperatorVarnameVersusTaskId(CheckerTestCase):
             ignore_position=True,
         ):
             self.checker.check_operator_varname_versus_task_id(
-                test_node, test_var_name, test_task_id
+                test_node, TaskParameters(test_var_name, test_task_id)
             )
 
     def test_varname_matches_task_id_should_not_message(self):
@@ -121,7 +122,9 @@ class TestCheckOperatorVarnameVersusTaskId(CheckerTestCase):
         test_name = "my_task"
 
         with self.assertNoMessages():
-            self.checker.check_operator_varname_versus_task_id(test_node, test_name, test_name)
+            self.checker.check_operator_varname_versus_task_id(
+                test_node, TaskParameters(test_name, test_name)
+            )
 
     @pytest.mark.parametrize(
         "test_var_name, test_task_id",
@@ -141,47 +144,47 @@ class TestCheckOperatorVarnameVersusTaskId(CheckerTestCase):
 
         with self.assertNoMessages():
             self.checker.check_operator_varname_versus_task_id(
-                test_node, test_var_name, test_task_id
+                test_node, TaskParameters(test_var_name, test_task_id)
             )
 
 
-class TestCheckCallableNameVersusTaskIt(CheckerTestCase):
+class TestCheckCallableNameVersusTaskId(CheckerTestCase):
     """Tests for the different-operator-varname-taskid function."""
 
     CHECKER_CLASS = pylint_airflow.checkers.operator.OperatorChecker
 
     def test_python_callable_name_does_not_match_underscored_task_id_should_message(self):
         test_node = astroid.extract_node("a = 1")
-        test_python_callable_name = "my_task_function"
         test_task_id = "my_task_id"
+        test_python_callable_name = "my_task_function"
 
         with self.assertAddsMessages(
             MessageTest(msg_id="match-callable-taskid", node=test_node), ignore_position=True
         ):
             self.checker.check_callable_name_versus_task_id(
-                test_node, test_python_callable_name, test_task_id
+                test_node, TaskParameters(test_task_id, test_task_id, test_python_callable_name)
             )
 
     def test_python_callable_name_matches_underscored_task_id_should_not_message(self):
         test_node = astroid.extract_node("a = 1")
-        test_python_callable_name = "_my_task_name"
         test_task_id = "my_task_name"
+        test_python_callable_name = "_my_task_name"
 
         with self.assertNoMessages():
             self.checker.check_callable_name_versus_task_id(
-                test_node, test_python_callable_name, test_task_id
+                test_node, TaskParameters(test_task_id, test_task_id, test_python_callable_name)
             )
 
     @pytest.mark.parametrize(
-        "test_python_callable_name, test_task_id",
+        "test_task_id, test_python_callable_name",
         [
-            ("callable_name", ""),
-            ("callable_name", None),
-            ("", "task_id"),
-            (None, "task_id"),
+            ("task_id", ""),
+            ("task_id", None),
+            ("", "callable_name"),
+            (None, "callable_name"),
             (None, None),
-            ("", None),
             (None, ""),
+            ("", None),
             ("", ""),
         ],
     )
@@ -192,7 +195,7 @@ class TestCheckCallableNameVersusTaskIt(CheckerTestCase):
 
         with self.assertNoMessages():
             self.checker.check_callable_name_versus_task_id(
-                test_node, test_python_callable_name, test_task_id
+                test_node, TaskParameters(test_task_id, test_task_id, test_python_callable_name)
             )
 
 


### PR DESCRIPTION
A bunch of refactor items:
- Break the OperatorChecker into more methods/functions
- Each pylint rule we implement has a corresponding `check_<rule>()` method, isolating the logic of the check from how we procure the nodes needed to compute the check result
- Test the `check` methods individually 
- Use a custom dataclass for extracting the task/operator parameters from an assignment node
- Move the pylint MSGS to the top of each module for easier reading
