### PR TITLE
move static functions outside of class definition

### DIFF
--- a/src/pylint_airflow/checkers/dag.py
+++ b/src/pylint_airflow/checkers/dag.py
@@ -1,4 +1,13 @@
-"""Checks on Airflow DAGs."""
+"""Checks on Airflow DAGs/module-wide rules.
+
+This module contains the DagChecker class and a collection of functions.
+
+DagChecker contains only:
+- Methods interfacing with the pylint checker API (i.e. `visit_<nodetype>()` methods)
+- Methods that add pylint messages for rules violations (`check_<message>()`)
+
+The module-level functions perform any work that isn't a pylint checker method or adding a message.
+"""
 from collections import defaultdict, OrderedDict
 from dataclasses import dataclass
 from typing import Dict, List, Optional

--- a/src/pylint_airflow/checkers/xcom.py
+++ b/src/pylint_airflow/checkers/xcom.py
@@ -6,18 +6,20 @@ from pylint.checkers import utils
 
 from pylint_airflow.__pkginfo__ import BASE_ID
 
+XCOM_CHECKER_MSGS = {
+    f"R{BASE_ID}00": (
+        "Return value from %s is stored as XCom but not used anywhere",
+        "unused-xcom",
+        "Return values from a python_callable function or execute() method are "
+        "automatically pushed as XCom.",
+    )
+}
+
 
 class XComChecker(checkers.BaseChecker):
     """Checks on Airflow XComs."""
 
-    msgs = {
-        f"R{BASE_ID}00": (
-            "Return value from %s is stored as XCom but not used anywhere",
-            "unused-xcom",
-            "Return values from a python_callable function or execute() method are "
-            "automatically pushed as XCom.",
-        )
-    }
+    msgs = XCOM_CHECKER_MSGS
 
     @utils.only_required_for_messages("unused-xcom")
     def visit_module(self, node: astroid.Module):

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring
-"""Tests for the DAG checker."""
+"""Tests for the DAG checker and its helper functions."""
 from collections import defaultdict
 from typing import Dict, List
 

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -12,6 +12,9 @@ from pylint_airflow.checkers.dag import (
     DagCallNode,
     find_dag_in_call_node,
     dagids_to_deduplicated_nodes,
+    collect_dags_in_assignments,
+    collect_dags_in_calls,
+    collect_dags_in_context_managers,
 )
 
 
@@ -400,16 +403,14 @@ class TestDagIdsToDeduplicatedNodesHelper:
         assert result == expected_result
 
 
-class TestFindDagsInAssignments(CheckerTestCase):
+class TestFindDagsInAssignments:
     """Tests for the method that collects DAGs from Assign nodes."""
-
-    CHECKER_CLASS = pylint_airflow.checkers.dag.DagChecker
 
     def test_no_nodes_collects_nothing(self, test_dagids_to_nodes):
         test_code = "list([1, 2, 3])"
         test_module = astroid.parse(test_code)
 
-        self.checker.collect_dags_in_assignments(test_module, test_dagids_to_nodes)
+        collect_dags_in_assignments(test_module, test_dagids_to_nodes)
 
         assert test_dagids_to_nodes == {}
 
@@ -456,21 +457,19 @@ class TestFindDagsInAssignments(CheckerTestCase):
             "test_dag_5": [test_body[11].value],
         }
 
-        self.checker.collect_dags_in_assignments(test_module, test_dagids_to_nodes)
+        collect_dags_in_assignments(test_module, test_dagids_to_nodes)
 
         assert test_dagids_to_nodes == expected_dagids_to_nodes
 
 
-class TestFindDagsInCalls(CheckerTestCase):
+class TestFindDagsInCalls:
     """Tests for the method that collects DAGs from Call nodes."""
-
-    CHECKER_CLASS = pylint_airflow.checkers.dag.DagChecker
 
     def test_no_nodes_collects_nothing(self, test_dagids_to_nodes):
         test_code = "list([1, 2, 3])"
         test_module = astroid.parse(test_code)
 
-        self.checker.collect_dags_in_calls(test_module, test_dagids_to_nodes)
+        collect_dags_in_calls(test_module, test_dagids_to_nodes)
 
         assert test_dagids_to_nodes == {}
 
@@ -514,21 +513,19 @@ class TestFindDagsInCalls(CheckerTestCase):
             "test_dag_5": [test_body[9].value],
         }
 
-        self.checker.collect_dags_in_calls(test_module, test_dagids_to_nodes)
+        collect_dags_in_calls(test_module, test_dagids_to_nodes)
 
         assert dagids_to_deduplicated_nodes(test_dagids_to_nodes) == expected_dagids_to_nodes
 
 
-class TestFindDagsInContextManagers(CheckerTestCase):
+class TestFindDagsInContextManagers:
     """Tests for the method that collects DAGs from With nodes (context manager blocks)."""
-
-    CHECKER_CLASS = pylint_airflow.checkers.dag.DagChecker
 
     def test_no_nodes_collects_nothing(self, test_dagids_to_nodes):
         test_code = "list([1, 2, 3])"
         test_module = astroid.parse(test_code)
 
-        self.checker.collect_dags_in_context_managers(test_module, test_dagids_to_nodes)
+        collect_dags_in_context_managers(test_module, test_dagids_to_nodes)
 
         assert test_dagids_to_nodes == {}
 
@@ -593,7 +590,7 @@ class TestFindDagsInContextManagers(CheckerTestCase):
             "test_dag_5": [test_body[12].items[0][0]],
         }
 
-        self.checker.collect_dags_in_context_managers(test_module, test_dagids_to_nodes)
+        collect_dags_in_context_managers(test_module, test_dagids_to_nodes)
 
         assert test_dagids_to_nodes == expected_dagids_to_nodes
 

--- a/tests/pylint_airflow/checkers/test_dag.py
+++ b/tests/pylint_airflow/checkers/test_dag.py
@@ -8,7 +8,11 @@ import pytest
 from pylint.testutils import CheckerTestCase, MessageTest
 
 import pylint_airflow
-from pylint_airflow.checkers.dag import DagCallNode, DagChecker, find_dag_in_call_node
+from pylint_airflow.checkers.dag import (
+    DagCallNode,
+    find_dag_in_call_node,
+    dagids_to_deduplicated_nodes,
+)
 
 
 @pytest.fixture(name="test_dagids_to_nodes")
@@ -363,11 +367,11 @@ class TestFindDagInCallNodeHelper:  # pylint: disable=protected-access,missing-f
         assert result is None
 
 
-class TestDagIdsToDeduplicatedNodesHelper:  # pylint: disable=protected-access,missing-function-docstring
-    """Test the _dagids_to_deduplicated_nodes static helper function."""
+class TestDagIdsToDeduplicatedNodesHelper:
+    """Test the dagids_to_deduplicated_nodes static helper function."""
 
     def test_empty_input_returns_empty_output(self):
-        result = DagChecker._dagids_to_deduplicated_nodes({})
+        result = dagids_to_deduplicated_nodes({})
 
         assert result == {}
 
@@ -378,7 +382,7 @@ class TestDagIdsToDeduplicatedNodesHelper:  # pylint: disable=protected-access,m
         call_4 = astroid.Call(lineno=3, col_offset=0, parent=None, end_lineno=0, end_col_offset=1)
         test_dict = {"dag_1": [call_1, call_2], "dag_2": [call_3, call_4]}
 
-        result = DagChecker._dagids_to_deduplicated_nodes(test_dict)
+        result = dagids_to_deduplicated_nodes(test_dict)
 
         assert result == test_dict
 
@@ -390,7 +394,7 @@ class TestDagIdsToDeduplicatedNodesHelper:  # pylint: disable=protected-access,m
         call_4 = astroid.Call(lineno=3, col_offset=0, parent=None, end_lineno=0, end_col_offset=1)
         test_dict = {"dag_1": [call_1, call_2, call_1], "dag_2": [call_3, call_4, call_4]}
 
-        result = DagChecker._dagids_to_deduplicated_nodes(test_dict)
+        result = dagids_to_deduplicated_nodes(test_dict)
 
         expected_result = {"dag_1": [call_1, call_2], "dag_2": [call_3, call_4]}
         assert result == expected_result
@@ -512,10 +516,7 @@ class TestFindDagsInCalls(CheckerTestCase):
 
         self.checker.collect_dags_in_calls(test_module, test_dagids_to_nodes)
 
-        assert (
-            DagChecker._dagids_to_deduplicated_nodes(test_dagids_to_nodes)
-            == expected_dagids_to_nodes
-        )
+        assert dagids_to_deduplicated_nodes(test_dagids_to_nodes) == expected_dagids_to_nodes
 
 
 class TestFindDagsInContextManagers(CheckerTestCase):

--- a/tests/pylint_airflow/checkers/test_operator.py
+++ b/tests/pylint_airflow/checkers/test_operator.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-function-docstring
-"""Tests for the Operator checker."""
+"""Tests for the Operator checker and its helper functions."""
 import astroid
 import pytest
 from pylint.testutils import CheckerTestCase, MessageTest


### PR DESCRIPTION
All static or static-eligible methods (methods that don't reference the `self` argument) have been moved out of the checker classes and up to the module level. This enhances the functions' testability and makes the checker class code easier to read as they now only contain visitor methods or methods that compute message criteria and add messages.
