### PR TITLE
augment XCom tests

### DIFF
--- a/src/pylint_airflow/checkers/xcom.py
+++ b/src/pylint_airflow/checkers/xcom.py
@@ -98,6 +98,8 @@ def get_xcoms_from_tasks(
                 for keyword in callable_func_call.keywords:
                     if keyword.arg == "task_ids" and isinstance(keyword.value, astroid.Const):
                         xcoms_pulled_taskids.add(keyword.value.value)
+                        # TODO: add support for xcom 'key' argument
+                        # TODO: add support for non-Const argument values
 
     return xcoms_pushed, xcoms_pulled_taskids
 

--- a/src/pylint_airflow/checkers/xcom.py
+++ b/src/pylint_airflow/checkers/xcom.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Set, Dict, Tuple
 
 import astroid
+from astroid import AttributeInferenceError
 from pylint import checkers
 from pylint.checkers import utils
 
@@ -77,7 +78,12 @@ def get_xcoms_from_tasks(
         if callable_func_name == "<lambda>":  # TODO support lambdas
             continue
 
-        callable_func = node.getattr(callable_func_name)[0]
+        try:
+            module_attribute = node.getattr(callable_func_name)
+        except AttributeInferenceError:
+            continue
+        else:
+            callable_func = module_attribute[0]
 
         if not isinstance(callable_func, astroid.FunctionDef):
             continue  # Callable_func is str not FunctionDef when imported

--- a/src/pylint_airflow/checkers/xcom.py
+++ b/src/pylint_airflow/checkers/xcom.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from typing import Set, Dict, Tuple
 
 import astroid
-from astroid import AttributeInferenceError
 from pylint import checkers
 from pylint.checkers import utils
 
@@ -78,12 +77,8 @@ def get_xcoms_from_tasks(
         if callable_func_name == "<lambda>":  # TODO support lambdas
             continue
 
-        try:
-            module_attribute = node.getattr(callable_func_name)
-        except AttributeInferenceError:
-            continue
-        else:
-            callable_func = module_attribute[0]
+        callable_func = node.getattr(callable_func_name)[0]
+        # ^ TODO: handle builtins and attribute imports that will raise on this call
 
         if not isinstance(callable_func, astroid.FunctionDef):
             continue  # Callable_func is str not FunctionDef when imported

--- a/src/pylint_airflow/checkers/xcom.py
+++ b/src/pylint_airflow/checkers/xcom.py
@@ -45,6 +45,7 @@ def get_task_ids_to_python_callable_specs(node: astroid.Module) -> Dict[str, Pyt
 
     # Store nodes containing python_callable arg as:
     # {task_id: PythonOperatorSpec(call node, python_callable func name)}
+
     task_ids_to_python_callable_specs = {}
     for call_node in call_nodes:
         if call_node.keywords:
@@ -52,7 +53,7 @@ def get_task_ids_to_python_callable_specs(node: astroid.Module) -> Dict[str, Pyt
             python_callable_function_name = ""
             for keyword in call_node.keywords:
                 if keyword.arg == "python_callable" and isinstance(keyword.value, astroid.Name):
-                    python_callable_function_name = keyword.value.name
+                    python_callable_function_name = keyword.value.name  # TODO: support lambdas
                 elif keyword.arg == "task_id" and isinstance(keyword.value, astroid.Const):
                     task_id = keyword.value.value  # TODO: support non-Const args
 

--- a/tests/pylint_airflow/checkers/test_xcom.py
+++ b/tests/pylint_airflow/checkers/test_xcom.py
@@ -15,6 +15,9 @@ from pylint_airflow.checkers.xcom import (
 
 
 class TestGetTaskIdsToPythonCallableSpecs:
+    """Tests the get_task_ids_to_python_callable_specs helper function which detects the
+    python_callable functions passed to PythonOperator constructions."""
+
     @pytest.mark.parametrize(
         "test_code",
         [
@@ -104,6 +107,8 @@ class TestGetTaskIdsToPythonCallableSpecs:
 
 
 class TestGetXComsFromTasks:
+    """Tests the get_xcoms_from_tasks helper function which detects the xcom pushes and pulls."""
+
     def test_should_return_empty_on_empty_input(self):
         result = get_xcoms_from_tasks(Mock(), {})
         # node argument isn't used when input dict is empty, so we can simply use a Mock object

--- a/tests/pylint_airflow/checkers/test_xcom.py
+++ b/tests/pylint_airflow/checkers/test_xcom.py
@@ -77,7 +77,6 @@ class TestGetTaskIdsToPythonCallableSpecs:
 
         assert result == expected_result
 
-    @pytest.mark.xfail(reason="Not yet implemented", raises=AssertionError, strict=True)
     def test_should_detect_imported_callable_as_attribute(self):
         test_code = """
         from airflow.operators.python_operator import PythonOperator

--- a/tests/pylint_airflow/checkers/test_xcom.py
+++ b/tests/pylint_airflow/checkers/test_xcom.py
@@ -160,7 +160,7 @@ class TestGetXComsFromTasks:
             print
 
         # TODO: detect a naked return statement and don't detect it as an xcom push
-        # TODO: detect function inputs as xcom pulls when appropriat
+        # TODO: detect function inputs as xcom pulls when appropriate
 
         local_task = PythonOperator(task_id="local_task", python_callable=task_func)
         aux_task = PythonOperator(task_id="aux_task", python_callable=aux_func)

--- a/tests/pylint_airflow/checkers/test_xcom.py
+++ b/tests/pylint_airflow/checkers/test_xcom.py
@@ -95,7 +95,6 @@ class TestGetTaskIdsToPythonCallableSpecs:
 
         assert result == expected_result
 
-    @pytest.mark.xfail(reason="Not yet implemented", raises=AssertionError, strict=True)
     def test_should_detect_imported_callable_as_name(self):
         test_code = """
         from airflow.operators.python_operator import PythonOperator
@@ -162,6 +161,9 @@ class TestGetXComsFromTasks:
 
         assert result == ({}, set())
 
+    @pytest.mark.xfail(
+        reason="Not yet implemented", raises=astroid.AttributeInferenceError, strict=True
+    )
     def test_should_skip_builtin_callable(self):
         test_code = """
         from airflow.operators.python_operator import PythonOperator
@@ -178,6 +180,9 @@ class TestGetXComsFromTasks:
 
         assert result == ({}, set())
 
+    @pytest.mark.xfail(
+        reason="Not yet implemented", raises=astroid.AttributeInferenceError, strict=True
+    )
     def test_should_skip_imported_callable_as_attribute(self):
         test_code = """
         from airflow.operators.python_operator import PythonOperator

--- a/tests/pylint_airflow/checkers/test_xcom.py
+++ b/tests/pylint_airflow/checkers/test_xcom.py
@@ -77,6 +77,7 @@ class TestGetTaskIdsToPythonCallableSpecs:
 
         assert result == expected_result
 
+    @pytest.mark.xfail(reason="Not yet implemented", raises=AssertionError, strict=True)
     def test_should_detect_imported_callable_as_attribute(self):
         test_code = """
         from airflow.operators.python_operator import PythonOperator


### PR DESCRIPTION
add testing for helper functions `get_task_ids_to_python_callable_specs` and `get_xcoms_from_tasks`